### PR TITLE
Prevent word-wrap

### DIFF
--- a/vue-filter-pretty-bytes.js
+++ b/vue-filter-pretty-bytes.js
@@ -14,14 +14,14 @@
 
      Vue.filter('prettyBytes', function (bytes, decimals, kib) {
        kib = kib || false
-       if (bytes === 0) return '0 Bytes'
+       if (bytes === 0) return '0 Bytes'
        if (isNaN(parseFloat(bytes)) && !isFinite(bytes)) return 'Not an number'
        const k = kib ? 1024 : 1000
        const dm = decimals || 2
        const sizes = kib ? ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'] : ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
        const i = Math.floor(Math.log(bytes) / Math.log(k))
 
-       return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+       return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
      })
   }
 


### PR DESCRIPTION
Word wrap in table cell looks ugly.

&nbsp; to glue unit to number.