### PR TITLE
Added Max-Unit-Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ KiB - Boolean
 {{ 15364878 | prettyBytes(1, true) }}
 ```
 Return: 14.7 MiB
+
+Max Unit
+```
+{{ 15364878 | prettyBytes(1, true, 'KiB') }}
+```
+Return: 15004.8 KiB

--- a/vue-filter-pretty-bytes.js
+++ b/vue-filter-pretty-bytes.js
@@ -9,18 +9,22 @@
      * @param {Number} bytes
      * @param {Number} decimals
      * @param {Boolean} kib
+     * @param {String} maxunit
      *
      */
 
-     Vue.filter('prettyBytes', function (bytes, decimals, kib) {
+     Vue.filter('prettyBytes', function (bytes, decimals, kib, maxunit) {
        kib = kib || false
        if (bytes === 0) return '0 Bytes'
        if (isNaN(parseFloat(bytes)) && !isFinite(bytes)) return 'Not an number'
        const k = kib ? 1024 : 1000
        const dm = decimals != null && !isNaN(decimals) && decimals >= 0 ? decimals : 2
        const sizes = kib ? ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'BiB'] : ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'BB']
-       const i = Math.floor(Math.log(bytes) / Math.log(k))
-
+       var i = Math.floor(Math.log(bytes) / Math.log(k))
+       if (maxunit != undefined) {
+         const index = sizes.indexOf(maxunit)
+         if (index != -1) i = index
+       }
        return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
      })
   }


### PR DESCRIPTION
Possibility to set a maximum unit for the Filter, e.G. if you want to show 1000GB instead of 1TB
Usefull for kind of lists where all values should be shown as max GB and some of them extend the 1000.